### PR TITLE
feat: support optional Lite Harness SDK provider

### DIFF
--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/agent-sdk.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/agent-sdk.ts
@@ -1,0 +1,56 @@
+import { query as claudeAgentQuery } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  SDKMessage,
+  SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+
+export type { SDKMessage, SDKUserMessage };
+
+type QueryArgs = Parameters<typeof claudeAgentQuery>[0];
+type QueryReturn = ReturnType<typeof claudeAgentQuery>;
+type QueryFunction = (args: QueryArgs) => QueryReturn;
+type LiteHarnessOptions = QueryArgs["options"] & {
+  agent?: string;
+  harness?: string;
+};
+
+const LITE_HARNESS_PROVIDER = "lite-harness";
+const LITE_HARNESS_DEFAULT_HARNESS = "claude-code";
+
+function getProvider() {
+  return (process.env.AGENT_SDK_PROVIDER || "claude-agent-sdk").trim().toLowerCase();
+}
+
+function withLiteHarnessOptions(args: QueryArgs): QueryArgs {
+  const options = (args.options || {}) as LiteHarnessOptions;
+  return {
+    ...args,
+    options: {
+      ...options,
+      harness:
+        process.env.LITE_HARNESS_HARNESS ||
+        process.env.LITE_HARNESS_AGENT ||
+        options.harness ||
+        options.agent ||
+        LITE_HARNESS_DEFAULT_HARNESS,
+      ...(process.env.LITE_HARNESS_MODEL
+        ? { model: process.env.LITE_HARNESS_MODEL }
+        : {}),
+    } as QueryArgs["options"],
+  };
+}
+
+async function loadQuery(): Promise<QueryFunction> {
+  if (getProvider() !== LITE_HARNESS_PROVIDER) {
+    return claudeAgentQuery;
+  }
+
+  const liteHarnessPackage = process.env.LITE_HARNESS_PACKAGE || "@lite-harness/sdk";
+  const liteHarness = (await import(liteHarnessPackage)) as {
+    query: QueryFunction;
+  };
+
+  return (args) => liteHarness.query(withLiteHarnessOptions(args));
+}
+
+export const query = await loadQuery();

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/assignment-workflow.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/assignment-workflow.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
-import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKMessage } from "./agent-sdk";
 import { z } from "zod";
 import { BLUE, CYAN, GREEN, YELLOW, RESET, log, printEvent } from "./utils";
 import { orderStore } from "./store/order-store";

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/baml-parsing.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/baml-parsing.ts
@@ -7,7 +7,7 @@
 
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "./agent-sdk";
 import { b } from "./baml_client";
 import { BLUE, CYAN, GREEN, RESET, YELLOW, log, printEvent } from "./utils";
 

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/chat.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/chat.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
-import { query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKUserMessage } from "./agent-sdk";
 import { BLUE, GREEN, RESET, createInputQueue, log, printEvent } from "./utils";
 
 async function main() {

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/dashboard-agent.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/dashboard-agent.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
-import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKMessage } from "./agent-sdk";
 import { z } from "zod";
 import { BLUE, CYAN, GREEN, YELLOW, RESET, log, printEvent } from "./utils";
 import { orderStore } from "./store/order-store";

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/delivery-tracking-agent.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/delivery-tracking-agent.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
-import { query, type SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKMessage } from "./agent-sdk";
 import { z } from "zod";
 import { BLUE, CYAN, GREEN, YELLOW, RESET, log, printEvent } from "./utils";
 import { orderStore } from "./store/order-store";

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/index.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/index.ts
@@ -1,4 +1,4 @@
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "./agent-sdk";
 import { BLUE, GREEN, RESET, log, printEvent } from "./utils";
 
 async function main() {

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/order-agent.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/order-agent.ts
@@ -1,7 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { existsSync, mkdirSync, appendFileSync } from "node:fs";
-import { query, type SDKMessage, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKMessage, type SDKUserMessage } from "./agent-sdk";
 import { z } from "zod";
 import {
   BLUE,

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/ralph.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/ralph.ts
@@ -14,7 +14,7 @@
 
 import { readFileSync, existsSync } from "node:fs";
 import { stdin } from "node:process";
-import { query } from "@anthropic-ai/claude-agent-sdk";
+import { query } from "./agent-sdk";
 import { BLUE, CYAN, RESET, YELLOW, log, printEvent } from "./utils";
 
 const LOOP_DELAY_MS = 10000;

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/structured-planning-with-json.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/structured-planning-with-json.ts
@@ -1,7 +1,7 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import { existsSync, mkdirSync, writeFileSync, appendFileSync } from "node:fs";
-import { query, type SDKMessage, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKMessage, type SDKUserMessage } from "./agent-sdk";
 import { z } from "zod";
 import {
   BLUE,

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/structured-planning.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/structured-planning.ts
@@ -1,6 +1,6 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
-import { query, type SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { query, type SDKUserMessage } from "./agent-sdk";
 import { z } from "zod";
 import {
   BLUE,

--- a/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/utils.ts
+++ b/2026-01-13-applying-12-factor-principles-to-coding-agent-sdks/src/utils.ts
@@ -1,5 +1,5 @@
 import { stderr } from "node:process";
-import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { SDKMessage } from "./agent-sdk";
 
 // ============================================================================
 // Colors


### PR DESCRIPTION
## Summary

Adds a local Agent SDK adapter to the 12-factor coding-agent demo package. The default path still uses `@anthropic-ai/claude-agent-sdk`, so existing examples behave the same.

When `AGENT_SDK_PROVIDER=lite-harness` is set, the adapter loads Lite Harness and keeps the same `query()` call sites while allowing the runtime harness to be selected either in code or with env vars.

## Swap harnesses in code

The examples can keep importing the local adapter:

```ts
import { query } from "./agent-sdk";
```

Then callers can choose the harness at the call site:

```ts
await query({
  prompt,
  options: {
    harness: "claude-code",
  },
});

await query({
  prompt,
  options: {
    harness: "codex",
  },
});

await query({
  prompt,
  options: {
    harness: "pi-ai",
  },
});
```

The default remains Claude Agent SDK unless `AGENT_SDK_PROVIDER=lite-harness` is enabled. `LITE_HARNESS_HARNESS` can also set the default harness for existing call sites without touching each query call.

## Why

I am a LiteLLM maintainer, and we are working on Lite Harness to solve the agent harness problem: letting developers keep one common SDK shape while swapping the runtime harness they want to use.

This package is a great fit because the examples already route all agent work through `query()`. This PR keeps the examples intact while making Claude Code, Codex, PI AI, or another Lite Harness runtime a small adapter/config choice. We would love feedback on whether this is useful for your Agent SDK workflow.

## How to try it

Default behavior remains unchanged:

```bash
bun run src/index.ts
```

Try Lite Harness after installing/packing the preview SDK in your environment:

```bash
AGENT_SDK_PROVIDER=lite-harness \
LITE_HARNESS_HARNESS=codex \
LITE_HARNESS_MODEL=gpt-5.5 \
bun run src/index.ts
```

Swap `LITE_HARNESS_HARNESS` to `claude-code`, `codex`, or `pi-ai` to choose the harness without changing the example command.

## Verification

From `2026-01-13-applying-12-factor-principles-to-coding-agent-sdks`:

- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" bun install --frozen-lockfile`
- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" bun run baml:generate`
- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" bun x tsc --noEmit`
- `PATH="/Users/ishaanjaffer/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" bun run src/index.ts` returned `Hello world` through the default Claude Agent SDK path.
- `git diff --check`
